### PR TITLE
Include query string in parsing of sitemap urls

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -17,35 +17,35 @@ module.exports = function (config, cb) {
 		var httpOptions = {
 			hostname: parsedUrl.hostname,
 			port: parsedUrl.port || (parsedUrl.protocol === 'https:' ? 443 : 80),
-			path: parsedUrl.pathname,
+            path: parsedUrl.path,
 			method: 'GET',
 			auth: config.http.auth
 		};
 		var client = parsedUrl.protocol === 'https:' ? https : http;
-		
+
 		var req = client.request(httpOptions, function (res) {
 			var data = '';
-			
+
 			res.setEncoding('utf8');
-			
+
 			if (res.statusCode !== 200) {
 				console.error('Status code returned ' + res.statusCode);
 				cb(sitemap, urls);
 				return;
 			}
-			
+
 			res.on('data', function (chunk) {
 				data += chunk;
 			});
-			
+
 			res.on('end', function (chunk, encoding) {
 				if (!!chunk) {
 					data += chunk;
 				}
-				
+
 				try {
 					var $ = cheerio.load(data);
-					
+
 					_.each($('url > loc'), function (loc) {
 						//console.log(loc.children);
 						if (!!loc.children.length > 0) {
@@ -57,7 +57,7 @@ module.exports = function (config, cb) {
 							console.error('No url found for ' + loc);
 						}
 					});
-					
+
 				} catch (ex) {
 					console.error(ex.message);
 					console.log(ex.stack);
@@ -66,12 +66,12 @@ module.exports = function (config, cb) {
 				}
 			});
 		});
-		
+
 		req.on('error', function (e) {
 			console.error(e.message);
 			cb(sitemap, urls);
 		});
-		
+
 		req.end();
 	});
 };


### PR DESCRIPTION
We use sitemaps which are dynamically build. The possibility to include parameters through the querystring was missing.

Eg. sitemap.php?lang=en will return a sitemap with only English urls and sitemap.php?lang=nl will only return Dutch urls.

Replaced _pathname_ with _path_ to take account of the query string parameters while parsing the urls of the sitemaps.