### PR TITLE
Fix for empty value check for default value

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -111,7 +111,7 @@ var parse = function (record, data, config) {
 			
 			// The key currently has a falsy value and
 			// a default value for this key does exists
-			if (!record[key] && !!config.defaults && !!config.defaults[key]) {
+			if ((!record[key] || !record[key].length) && !!config.defaults && !!config.defaults[key]) {
 				record[key] = config.defaults[key];
 			}
 		} else {


### PR DESCRIPTION
record[key] can be an empty value so !record[key] is not valid to check if record[key] is empty. Added check on array length.