### PR TITLE
Replaced deprecated function

### DIFF
--- a/app.js
+++ b/app.js
@@ -166,7 +166,7 @@ var removeOldEntries = function () {
 		if (_.isInteger(config.oldentries) && config.oldentries > 0) {
 			console.log()
 			console.log('Removing old entries...');
-			pages.deleteByQuery('*', {
+			pages.deleteBy('*', {
 				numericFilters: ['timestamp<' + (new Date().getTime() - config.oldentries)]
 			}, function (error, content) {
 				if (!!error) {

--- a/app.js
+++ b/app.js
@@ -166,7 +166,7 @@ var removeOldEntries = function () {
 		if (_.isInteger(config.oldentries) && config.oldentries > 0) {
 			console.log()
 			console.log('Removing old entries...');
-			pages.deleteBy('*', {
+			pages.deleteBy({
 				numericFilters: ['timestamp<' + (new Date().getTime() - config.oldentries)]
 			}, function (error, content) {
 				if (!!error) {


### PR DESCRIPTION
The function deleteByQuery has been deprecated. https://github.com/algolia/algoliasearch-client-javascript/wiki/Deprecated#indexdeletebyquery
We must now use deleteBy. After running the crawler with the new function, everything seems to be working fine