### PR TITLE
Move if condition outside of map

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -108,12 +108,10 @@ const parse = (record, data, config) => {
 			}
 			
 			// A type converter for this key does exists
-			if (!!config.types && !!config.types[key]) {
+			if (!!config.types && !!config.types[key] && !!types[config.types[key]]) {
 				// Cast all values
 				record[key] = _.map(record[key], (value) => {
-					if (!!types[config.types[key]]) {
-						return types[config.types[key]](value);
-					}
+					return types[config.types[key]](value);
 				});
 			}
 			


### PR DESCRIPTION
The map only needs to be done when there is a matching type in the config for the current key.