### PR TITLE
Manage url that have non encoded characters

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -189,7 +189,11 @@ module.exports = (data, cb) => {
 	const isRetry = !!data.isRetry;
 	const url = data.url;
 	const action = data.url.action;
-	const parsedUrl = URL.parse(url.url);
+	// To get rid of invalid source urls,
+	// we decode the source and then encode it back.
+	// This prevent us from double encoding source urls
+	const encodedUrl = encodeURI(decodeURI(url.url));
+	const parsedUrl = URL.parse(encodedUrl);
 	const client = parsedUrl.protocol === 'https:' ? https : http;
 	const httpOptions = {
 		hostname: parsedUrl.hostname,


### PR DESCRIPTION
If the crawler tries to request a url that has non encoded characters, it will simply stop there and giv an error. 

To fix this, url is first decoded to decoded what is already present in the url so that there wil not be a double encoding. It is then encoded.